### PR TITLE
Initial setup for revocation Lambda handler

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,36 +1,53 @@
-name: Deploy Revocation Lambda
+name: Deploy Lambda
 
 on:
   push:
     branches:
-      - revocation-lambda   # your branch
+      - master   # CHANGED: was told to deploy ONLY on master (not your branch)
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGIONS: "us-east-1"   # Is this right? can expand later if needed???
 
 jobs:
   deploy:
+    name: Build and Deploy
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.22"
 
-      - name: Build Lambda binary
+      - name: Build Lambda
         run: |
-          GOOS=linux GOARCH=amd64 go build -o main main.go
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o bootstrap -tags lambda.norpc main.go
+          # CHANGED: renamed zip file to match THIS lambda (not issuer or bitstring)
+          zip revocation-lambda.zip bootstrap
 
-      - name: Zip Lambda
-        run: zip function.zip main
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::043189681060:role/ZeroVerifyGitHubActionsLambdaDeployment
+          aws-region: us-east-1
 
-      - name: Deploy to AWS Lambda
+      - name: Deploy to AWS
         run: |
+          bucket_name="zeroverify-deployment-artifacts-us-east-1"
+
+          aws s3 cp revocation-lambda.zip s3://${bucket_name}/lambda/revocation-lambda.zip --region us-east-1
+
           aws lambda update-function-code \
-            --function-name YOUR_FUNCTION_NAME \ 
-            --zip-file fileb://function.zip \
-            --region YOUR_REGION
+            --function-name zeroverify-revocation \
+            --s3-bucket ${bucket_name} \
+            --s3-key lambda/revocation-lambda.zip \
+            --region us-east-1
 
-# replace YOUR_FUNCTION_NAME and YOUR_REGION with your actual Lambda function name and AWS region. You also need to set up AWS credentials in your GitHub repository secrets for this to work.
-
+          echo "Successfully deployed revocation lambda"

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -1,0 +1,36 @@
+name: Deploy Revocation Lambda
+
+on:
+  push:
+    branches:
+      - revocation-lambda   # your branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+
+      - name: Build Lambda binary
+        run: |
+          GOOS=linux GOARCH=amd64 go build -o main main.go
+
+      - name: Zip Lambda
+        run: zip function.zip main
+
+      - name: Deploy to AWS Lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name YOUR_FUNCTION_NAME \ 
+            --zip-file fileb://function.zip \
+            --region YOUR_REGION
+
+# replace YOUR_FUNCTION_NAME and YOUR_REGION with your actual Lambda function name and AWS region. You also need to set up AWS credentials in your GitHub repository secrets for this to work.
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module revocation-lambda
+
+go 1.26.1
+
+require github.com/aws/aws-lambda-go v1.54.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module revocation-lambda
+module github.com/ZeroVerify/revocation-lambda
 
 go 1.26.1
 
-require github.com/aws/aws-lambda-go v1.54.0 // indirect
+require github.com/aws/aws-lambda-go v1.54.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,10 @@
 github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
+github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,0 +1,23 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+type Handler struct{}
+
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+func (h *Handler) Handle(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	// NOTE: using API Gateway request (NOT DynamoDB) because revocation = API endpoint
+	// also keeping it super simple (no fake proof logic like last time LOL)
+
+	return events.APIGatewayProxyResponse{
+		StatusCode: 200,
+		Body:       `{"message": "Hello, World!"}`, // just a basic response for now
+	}, nil
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type RequestBody struct {
+	CredentialID string `json:"credentialId"`
+	Proof        string `json:"proof"`
+}
+
+func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+
+	var body RequestBody
+
+	err := json.Unmarshal([]byte(request.Body), &body)
+	if err != nil {
+		return events.APIGatewayProxyResponse{
+			StatusCode: http.StatusBadRequest,
+			Body:       "Invalid request",
+		}, nil
+	}
+
+	// TEMP proof check
+	if body.Proof != "valid" {
+		return events.APIGatewayProxyResponse{
+			StatusCode: http.StatusBadRequest,
+			Body:       "Invalid proof",
+		}, nil
+	}
+
+	// simulate revocation
+	println("Revoked credential:", body.CredentialID)
+
+	return events.APIGatewayProxyResponse{
+		StatusCode: http.StatusAccepted,
+		Body:       "Credential revoked",
+	}, nil
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		}, nil
 	}
 
-	// TEMP proof check
+	// TEMP proof check, I REPEAT THIS IS FAKE LOL, it is just a place holder for the actual proof verification logic that should be implemented in a real application
 	if body.Proof != "valid" {
 		return events.APIGatewayProxyResponse{
 			StatusCode: http.StatusBadRequest,
@@ -34,7 +34,7 @@ func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		}, nil
 	}
 
-	// simulate revocation
+	// simulate revocation, THIS IS ALSO FAKE. Later it will update DynamoDB (real database) to mark the credential as revoked
 	println("Revoked credential:", body.CredentialID)
 
 	return events.APIGatewayProxyResponse{

--- a/main.go
+++ b/main.go
@@ -1,48 +1,12 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
-	"net/http"
+	"github.com/ZeroVerify/revocation-lambda/internal/handler"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
-type RequestBody struct {
-	CredentialID string `json:"credentialId"`
-	Proof        string `json:"proof"`
-}
-
-func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-
-	var body RequestBody
-
-	err := json.Unmarshal([]byte(request.Body), &body)
-	if err != nil {
-		return events.APIGatewayProxyResponse{
-			StatusCode: http.StatusBadRequest,
-			Body:       "Invalid request",
-		}, nil
-	}
-
-	// TEMP proof check, I REPEAT THIS IS FAKE LOL, it is just a place holder for the actual proof verification logic that should be implemented in a real application
-	if body.Proof != "valid" {
-		return events.APIGatewayProxyResponse{
-			StatusCode: http.StatusBadRequest,
-			Body:       "Invalid proof",
-		}, nil
-	}
-
-	// simulate revocation, THIS IS ALSO FAKE. Later it will update DynamoDB (real database) to mark the credential as revoked
-	println("Revoked credential:", body.CredentialID)
-
-	return events.APIGatewayProxyResponse{
-		StatusCode: http.StatusAccepted,
-		Body:       "Credential revoked",
-	}, nil
-}
-
 func main() {
-	lambda.Start(handler)
+	h := handler.NewHandler()
+	lambda.Start(h.Handle)
 }


### PR DESCRIPTION
Initial setup for revocation Lambda handler

- Created Go module and added AWS Lambda dependencies
- Implemented Lambda handler structure for API Gateway requests
- Added request parsing for credentialId and proof

Temporary logic (for development/testing):
- Mock proof validation (proof must equal "valid")
- Simulated revocation using print statement (no DB yet)

Purpose:
- Establish working structure for revocation endpoint
- Enable testing of request flow before full integration

Next steps:
- Integrate verifier-go for real proof validation
- Connect DynamoDB to update credential status to REVOKED